### PR TITLE
fix: add canonical URL to the ClipStash site

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -7,6 +7,7 @@
     <title>ClipStash — Clipboard Manager for macOS</title>
     <meta name="description"
         content="Lightweight, privacy-first clipboard history manager for macOS. No network, no telemetry, just pure productivity.">
+    <link rel="canonical" href="https://kikuai-lab.github.io/ClipStash/">
     <link rel="icon" type="image/png" href="assets/icon.png">
     <style>
         :root {


### PR DESCRIPTION
## Summary

- add one self-referencing canonical URL to the GitHub Pages product surface
- preserve the existing title, description, content, styling, and product behavior

## Surface and scope

Surface: `pages-product`
Verdict: `site-baseline`

This intentionally does not add schema, robots, sitemap, FAQ, Open Graph/Twitter metadata, new assets, benchmarks, or broader marketing copy. Security, performance, App Store, and release claims remain proof-gated follow-up work.

## Verification

- `git diff --check origin/main...HEAD` — passed
- exactly one canonical is present and equals `https://kikuai-lab.github.io/ClipStash/`
- only `docs/index.html` changed

Metadata impact: none outside the deployed HTML.
Branch-protection impact: none.
Secrets check: skipped; one-line HTML metadata-only change with no config or examples touched.

Tracks kiku-jw/kikuai-project-map#13.
